### PR TITLE
This field no loger exists

### DIFF
--- a/cacahuate/indexes.py
+++ b/cacahuate/indexes.py
@@ -12,7 +12,6 @@ def create_indexes(config):
     db.execution.create_index("started_at")
     db.execution.create_index("finished_at")
 
-    db.history.create_index("id", unique=True)
     db.history.create_index("status")
     db.history.create_index("execution.id")
     db.history.create_index("started_at")


### PR DESCRIPTION
This field was deprecated long time ago and if you're creating a second insertion to `history` collection it fails with an mongo unique error code