### PR TITLE
Categulario/if invalidation

### DIFF
--- a/cacahuate/cascade.py
+++ b/cacahuate/cascade.py
@@ -3,7 +3,7 @@ validation-type nodes and patch requests '''
 from cacahuate.errors import EndOfProcess
 
 
-def cascade_invalidate(xml, state, mongo, config, invalidated, comment):
+def cascade_invalidate(xml, state, invalidated, comment):
     ''' computes a set of fields to be marked as invalid given the
     original `invalidated` set of fields. '''
     # because this could cause a recursive import
@@ -90,15 +90,7 @@ def cascade_invalidate(xml, state, mongo, config, invalidated, comment):
         updates[node_state_path] = node_state
         updates[comment_path] = comment
 
-    # update state
-    collection = mongo[
-        config['EXECUTION_COLLECTION']
-    ]
-    collection.update_one({
-        'id': state['id'],
-    }, {
-        '$set': updates,
-    })
+    return updates
 
 
 def track_next_node(xml, state, mongo, config):

--- a/cacahuate/handler.py
+++ b/cacahuate/handler.py
@@ -456,14 +456,22 @@ class Handler:
         # retrieve updated state
         state = next(execution_collection.find({'id': execution.id}))
 
-        cascade_invalidate(
+        state_updates = cascade_invalidate(
             xml,
             state,
-            mongo,
-            self.config,
             message['inputs'],
             message['comment']
         )
+
+        # update state
+        collection = mongo[
+            self.config['EXECUTION_COLLECTION']
+        ]
+        collection.update_one({
+            'id': state['id'],
+        }, {
+            '$set': state_updates,
+        })
 
         # retrieve updated state
         state = next(execution_collection.find({'id': execution.id}))

--- a/cacahuate/node.py
+++ b/cacahuate/node.py
@@ -712,7 +712,14 @@ class Conditional(Node):
         ])]
 
     def dependent_refs(self, invalidated, node_state):
-        return set()
+        ''' IF nodes should alwas be invalidated in case the value they depend
+        on changes, so this function just returns this node's ref'''
+        actor = next(iter(node_state['actors']['items'].keys()))
+
+        return {'{node}.{actor}.0:approval.response'.format(
+            node=self.id,
+            actor=actor,
+        )}
 
 
 class If(Conditional):

--- a/test/nodes/if_test.py
+++ b/test/nodes/if_test.py
@@ -578,7 +578,9 @@ def test_invalidated_conditional(config, mongo):
     mongo[config["EXECUTION_COLLECTION"]].insert_one({
         '_type': 'execution',
         'id': ptr.proxy.execution.get().id,
-        'state': Xml.load(config, ptr.proxy.execution.get().process_name).get_state(),
+        'state': Xml.load(
+            config, ptr.proxy.execution.get().process_name
+        ).get_state(),
     })
 
     handler.call({

--- a/test/nodes/if_test.py
+++ b/test/nodes/if_test.py
@@ -573,13 +573,14 @@ def test_invalidated_conditional(config, mongo):
     user = make_user('juan', 'Juan')
     process_filename = 'condition_invalidated.2019-10-08.xml'
     ptr = make_pointer(process_filename, 'start_node')
+    execution = ptr.proxy.execution.get()
     channel = MagicMock()
 
     mongo[config["EXECUTION_COLLECTION"]].insert_one({
         '_type': 'execution',
-        'id': ptr.proxy.execution.get().id,
+        'id': execution.id,
         'state': Xml.load(
-            config, ptr.proxy.execution.get().process_name
+            config, execution.process_name
         ).get_state(),
     })
 
@@ -639,3 +640,186 @@ def test_invalidated_conditional(config, mongo):
     }, channel)
     ptr = Pointer.get_all()[0]
     assert ptr.node_id == 'start_node'
+
+    channel = MagicMock()
+    handler.call({
+        'command': 'step',
+        'pointer_id': ptr.id,
+        'user_identifier': user.identifier,
+        'input': [Form.state_json('form1', [
+            {
+                'name': 'value',
+                'type': 'int',
+                'value': -3,
+            },
+        ])],
+    }, channel)
+    ptr = Pointer.get_all()[0]
+    assert ptr.node_id == 'if_node'
+
+    # rabbit called
+    channel.basic_publish.assert_called_once()
+    args = channel.basic_publish.call_args[1]
+    rabbit_call = {
+        'command': 'step',
+        'pointer_id': ptr.id,
+        'input': [Form.state_json('if_node', [
+            {
+                'name': 'condition',
+                'name': 'condition',
+                'state': 'valid',
+                'type': 'bool',
+                'value': False,
+            },
+        ])],
+        'user_identifier': '__system__',
+    }
+    assert json.loads(args['body']) == rabbit_call
+
+    handler.call(rabbit_call, channel)
+
+    # pointer moved
+    assert Pointer.get(ptr.id) is None
+    # Execution finished
+    assert Pointer.get_all() == []
+
+    # state is coherent
+    state = next(mongo[config["EXECUTION_COLLECTION"]].find({
+        'id': execution.id,
+    }))
+
+    del state['_id']
+    del state['finished_at']
+
+    assert state == {
+        '_type': 'execution',
+        'id': execution.id,
+        'state': {
+            '_type': ':sorted_map',
+            'items': {
+                'start_node': {
+                    '_type': 'node',
+                    'type': 'action',
+                    'id': 'start_node',
+                    'state': 'valid',
+                    'comment': 'I do not like it',
+                    'actors': {
+                        '_type': ':map',
+                        'items': {
+                            'juan': {
+                                '_type': 'actor',
+                                'forms': [Form.state_json('form1', [
+                                    {
+                                        'name': 'value',
+                                        'type': 'int',
+                                        'value': -3,
+                                    },
+                                ])],
+                                'state': 'valid',
+                                'user': {
+                                    '_type': 'user',
+                                    'identifier': 'juan',
+                                    'fullname': 'Juan',
+                                },
+                            },
+                        },
+                    },
+                    'milestone': False,
+                    'name': 'Node 1',
+                    'description': 'the value subject to inspection',
+                },
+
+                'if_node': {
+                    '_type': 'node',
+                    'type': 'if',
+                    'id': 'if_node',
+                    'state': 'valid',
+                    'comment': 'I do not like it',
+                    'actors': {
+                        '_type': ':map',
+                        'items': {
+                            '__system__': {
+                                '_type': 'actor',
+                                'forms': [Form.state_json('if_node', [
+                                    {
+                                        'name': 'condition',
+                                        'value': False,
+                                        'type': 'bool',
+                                        'state': 'valid',
+                                    },
+                                ])],
+                                'state': 'valid',
+                                'user': {
+                                    '_type': 'user',
+                                    'identifier': '__system__',
+                                    'fullname': 'System',
+                                },
+                            },
+                        },
+                    },
+                    'milestone': False,
+                    'name': 'IF if_node',
+                    'description': 'IF if_node',
+                },
+
+                'validation_node': {
+                    '_type': 'node',
+                    'type': 'validation',
+                    'id': 'validation_node',
+                    'state': 'invalid',
+                    'comment': 'I do not like it',
+                    'actors': {
+                        '_type': ':map',
+                        'items': {
+                            'juan': {
+                                '_type': 'actor',
+                                'forms': [Form.state_json('validation_node', [
+                                    {
+                                        'name': 'response',
+                                        'value': 'reject',
+                                        'state': 'invalid',
+                                    },
+                                    {
+                                        'name': 'comment',
+                                        'value': 'I do not like it',
+                                    },
+                                    {
+                                        'name': 'inputs',
+                                        'value': [{
+                                            'ref': 'start_node.juan.0:form1'
+                                                   '.value',
+                                        }],
+                                    },
+                                ], state='invalid')],
+                                'state': 'invalid',
+                                'user': {
+                                    '_type': 'user',
+                                    'identifier': 'juan',
+                                    'fullname': 'Juan',
+                                },
+                            },
+                        },
+                    },
+                    'milestone': False,
+                    'name': 'The validation',
+                    'description': 'This node invalidates the original value',
+                },
+            },
+            'item_order': ['start_node', 'if_node', 'validation_node'],
+        },
+        'status': 'finished',
+        'values': {
+            'form1': {'value': -3},
+            'if_node': {'condition': False},
+            'validation_node': {
+                'comment': 'I do not like it',
+                'inputs': [{'ref': 'start_node.juan.0:form1.value'}],
+                'response': 'reject',
+            },
+        },
+        'actors': {
+            'start_node': 'juan',
+            'if_node': '__system__',
+            'validation_node': 'juan',
+        },
+    }

--- a/xml/condition_invalidated.2019-10-08.xml
+++ b/xml/condition_invalidated.2019-10-08.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://tracsa.github.io/vi-xml/proceso_transform.xsl" ?>
+<process-spec>
+  <process-info>
+    <author>categulario</author>
+    <date>2019-10-08</date>
+    <name>Invalidate a value used in a conditional</name>
+    <public>false</public>
+    <description>This process tests that an If node respects the updated value of an invalidated node used in its conditional expression</description>
+  </process-info>
+  <process>
+    <action id="start_node">
+      <node-info>
+        <name>Node 1</name>
+        <description>the value subject to inspection</description>
+      </node-info>
+      <auth-filter backend="anyone"></auth-filter>
+      <form-array>
+        <form id="form1">
+          <input type="int" name="value" label="The value"></input>
+        </form>
+      </form-array>
+    </action>
+
+    <if id="if_node">
+      <condition>form1.value > 0</condition>
+      <block>
+
+        <validation id="validation_node" >
+          <dependencies>
+            <dep>form1.value</dep>
+          </dependencies>
+          <node-info>
+            <name>The validation</name>
+            <description>This node invalidates the original value</description>
+          </node-info>
+          <auth-filter backend="backref">
+            <param name="identifier" type="ref">user#start_node</param>
+          </auth-filter>
+        </validation>
+
+      </block>
+    </if>
+  </process>
+</process-spec>


### PR DESCRIPTION
Cuando se invalida un campo que es usado en un if éste no respetaba el cambio de valor y procedía con el valor anterior. Ya no más! Los if opresores fueron removidos y en su lugar se pusieron unos que respetan los cambios de opinión de los nodos anteriores. El producto viene probado, viene calado, 10 pesos el vale, 10 pesos le cuesta.