### PR TITLE
Categulario/request multiple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-.PHONY: publish pytest clean lint xmllint clear-objects build test
+.PHONY: publish pytest clean lint xmllint xml_validate clear-objects build test xml
 
 build:
 	./setup.py sdist && ./setup.py bdist_wheel
 
 test: pytest lint xmllint xml_validate
+
+xml: xmllint xml_validate
 
 publish:
 	twine upload dist/* && git push && git push --tags

--- a/cacahuate/http/views/templates.py
+++ b/cacahuate/http/views/templates.py
@@ -1,9 +1,11 @@
 from coralillo.errors import ModelNotFoundError
-from cacahuate.http.wsgi import app, mongo
 from datetime import datetime
 from jinja2 import Template, environment
 import json
 import os
+
+from cacahuate.http.wsgi import app, mongo
+from cacahuate.utils import get_values
 
 
 def to_pretty_json(value):
@@ -49,8 +51,9 @@ def execution_template(id):
 
     # prepare default template
     default = []
-    values = execution['values']
-    for key in values:
+    context = get_values(execution)
+
+    for key in context:
         token = '<div><h2>{}</h2><pre>{{{{ {} | pretty }}}}</pre></div>'
         default.append(token.format(key, key))
 
@@ -79,4 +82,4 @@ def execution_template(id):
             template = Template(contents.read())
 
     # return template interpolation
-    return template.render(**values)
+    return template.render(**context)

--- a/cacahuate/jsontypes.py
+++ b/cacahuate/jsontypes.py
@@ -68,174 +68,84 @@ class Map:
         return self.items[item]
 
 
-class MultiValueMap(dict):
+class MultiFormDict:
     """
-    A subclass of dictionary customized to handle multiple values for the
-    same key.
-
-    >>> d = MultiValueDict({'name': ['Adrian', 'Simon'], 'position': ['Developer']})
-    >>> d['name']
-    'Simon'
-    >>> d.getlist('name')
-    ['Adrian', 'Simon']
-    >>> d.getlist('doesnotexist')
-    []
-    >>> d.getlist('doesnotexist', ['Adrian', 'Simon'])
-    ['Adrian', 'Simon']
-    >>> d.get('lastname', 'nonexistent')
-    'nonexistent'
-    >>> d.setlist('lastname', ['Holovaty', 'Willison'])
-
-    This class exists to solve the irritating problem raised by cgi.parse_qs,
-    which returns a list for every key, even though most Web forms submit
-    single name-value pairs.
+    A special dictionary that can take values from a list of dictionaries
+    that share the keys, by default returns the value of the last one
     """
-    def __init__(self, key_to_list_mapping=()):
-        super().__init__(key_to_list_mapping)
+    def __init__(self, dict_list):
+        self.dict_list = dict_list
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, super().__repr__())
+        return repr(self.dict_list)
 
     def __getitem__(self, key):
         """
         Return the last data value for this key, or [] if it's an empty list;
         raise KeyError if not found.
         """
-        try:
-            list_ = super().__getitem__(key)
-        except KeyError:
-            raise MultiValueDictKeyError(key)
-        try:
-            return list_[-1]
-        except IndexError:
-            return []
+        if len(self.dict_list) == 0:
+            raise KeyError(key)
 
-    def __setitem__(self, key, value):
-        super().__setitem__(key, [value])
-
-    def __copy__(self):
-        return self.__class__([
-            (k, v[:])
-            for k, v in self.lists()
-        ])
-
-    def __deepcopy__(self, memo):
-        result = self.__class__()
-        memo[id(self)] = result
-        for key, value in dict.items(self):
-            dict.__setitem__(result, copy.deepcopy(key, memo),
-                             copy.deepcopy(value, memo))
-        return result
-
-    def __getstate__(self):
-        return {**self.__dict__, '_data': {k: self._getlist(k) for k in self}}
-
-    def __setstate__(self, obj_dict):
-        data = obj_dict.pop('_data', {})
-        for k, v in data.items():
-            self.setlist(k, v)
-        self.__dict__.update(obj_dict)
+        return self.dict_list[-1][key]
 
     def get(self, key, default=None):
         """
         Return the last data value for the passed key. If key doesn't exist
         or value is an empty list, return `default`.
         """
+        if len(self.dict_list) == 0:
+            return default
+
         try:
-            val = self[key]
+            return self.dict_list[-1][key]
         except KeyError:
             return default
-        if val == []:
-            return default
-        return val
 
-    def _getlist(self, key, default=None, force_list=False):
+    def getlist(self, key, default=None):
+        ''' return a list of values for this key where every missing key of an
+        underlaying dict is replaced by `default` '''
+        if len(self.dict_list) == 0:
+            return []
+
+        return [d.get(key, default) for d in self.dict_list]
+
+    def list(self):
         """
         Return a list of values for the key.
 
         Used internally to manipulate values list. If force_list is True,
         return a new copy of values.
         """
-        try:
-            values = super().__getitem__(key)
-        except KeyError:
-            if default is None:
-                return []
-            return default
-        else:
-            if force_list:
-                values = list(values) if values is not None else None
-            return values
-
-    def getlist(self, key, default=None):
-        """
-        Return the list of values for the key. If key doesn't exist, return a
-        default value.
-        """
-        return self._getlist(key, default, force_list=True)
-
-    def setlist(self, key, list_):
-        super().__setitem__(key, list_)
-
-    def setdefault(self, key, default=None):
-        if key not in self:
-            self[key] = default
-            # Do not return default here because __setitem__() may store
-            # another value -- QueryDict.__setitem__() does. Look it up.
-        return self[key]
-
-    def setlistdefault(self, key, default_list=None):
-        if key not in self:
-            if default_list is None:
-                default_list = []
-            self.setlist(key, default_list)
-            # Do not return default_list here because setlist() may store
-            # another value -- QueryDict.setlist() does. Look it up.
-        return self._getlist(key)
-
-    def appendlist(self, key, value):
-        """Append an item to the internal list associated with key."""
-        self.setlistdefault(key).append(value)
+        return self.dict_list[:]
 
     def items(self):
         """
         Yield (key, value) pairs, where value is the last item in the list
         associated with the key.
         """
-        for key in self:
-            yield key, self[key]
+        if len(self.dict_list) == 0:
+            return None
 
-    def lists(self):
-        """Yield (key, list) pairs."""
-        return iter(super().items())
+        return self.dict_list[-1].items()
 
     def values(self):
         """Yield the last value on every key list."""
-        for key in self:
-            yield self[key]
+        if len(self.dict_list) == 0:
+            return None
 
-    def copy(self):
-        """Return a shallow copy of this object."""
-        return copy.copy(self)
+        return self.dict_list[-1].values()
 
-    def update(self, *args, **kwargs):
-        """Extend rather than replace existing key lists."""
-        if len(args) > 1:
-            raise TypeError("update expected at most 1 argument, got %d" % len(args))
-        if args:
-            other_dict = args[0]
-            if isinstance(other_dict, MultiValueDict):
-                for key, value_list in other_dict.lists():
-                    self.setlistdefault(key).extend(value_list)
-            else:
-                try:
-                    for key, value in other_dict.items():
-                        self.setlistdefault(key).append(value)
-                except TypeError:
-                    raise ValueError("MultiValueDict.update() takes either a MultiValueDict or dictionary")
-        for key, value in kwargs.items():
-            self.setlistdefault(key).append(value)
+    def keys(self):
+        """Yield the last value on every key list."""
+        if len(self.dict_list) == 0:
+            return None
+
+        return self.dict_list[-1].keys()
 
     def dict(self):
         """Return current object as a dict with singular values."""
-        return {key: self[key] for key in self}
+        try:
+            return self.dict_list[-1].copy()
+        except IndexError:
+            return {}

--- a/cacahuate/jsontypes.py
+++ b/cacahuate/jsontypes.py
@@ -70,9 +70,15 @@ class Map:
 
 class MultiFormDict:
     """
-    A special dictionary that can take values from a list of dictionaries
-    that share the keys, by default returns the value of the last one
+    A special dictionary that can take values from a list of dictionaries that
+    share the keys, by default returns the value of the last one.
+
+    It is used to wrap the ``'values'`` key of an execution document so it can
+    be used in templates and other places as a normal ``dict`` that by default
+    returns the values of the last dictionary but allows to access the rest of
+    them via the provided functions.
     """
+
     def __init__(self, dict_list):
         self.dict_list = dict_list
 
@@ -91,8 +97,8 @@ class MultiFormDict:
 
     def get(self, key, default=None):
         """
-        Return the last data value for the passed key. If key doesn't exist
-        or value is an empty list, return `default`.
+        Return the value for the given key. Takes the value of the last
+        dict. If the key doesn't exist returns ``default``.
         """
         if len(self.dict_list) == 0:
             return default
@@ -104,25 +110,23 @@ class MultiFormDict:
 
     def getlist(self, key, default=None):
         ''' return a list of values for this key where every missing key of an
-        underlaying dict is replaced by `default` '''
+        underlaying dict is replaced by ``default``. '''
         if len(self.dict_list) == 0:
             return []
 
         return [d.get(key, default) for d in self.dict_list]
 
-    def list(self):
+    def all(self):
         """
-        Return a list of values for the key.
-
-        Used internally to manipulate values list. If force_list is True,
-        return a new copy of values.
+        Returns an iterator over the different dictionaries contained in this
+        object.
         """
-        return self.dict_list[:]
+        for d in self.dict_list:
+            yield d
 
     def items(self):
         """
-        Yield (key, value) pairs, where value is the last item in the list
-        associated with the key.
+        Yield (key, value) pairs, from the last contained dict.
         """
         if len(self.dict_list) == 0:
             return None
@@ -130,21 +134,21 @@ class MultiFormDict:
         return self.dict_list[-1].items()
 
     def values(self):
-        """Yield the last value on every key list."""
+        """ Yield all the values from the last contained dict. """
         if len(self.dict_list) == 0:
             return None
 
         return self.dict_list[-1].values()
 
     def keys(self):
-        """Yield the last value on every key list."""
+        """ Yield all the keys from the last contained dict. """
         if len(self.dict_list) == 0:
             return None
 
         return self.dict_list[-1].keys()
 
     def dict(self):
-        """Return current object as a dict with singular values."""
+        """ Return a copy of the last contained dict """
         try:
             return self.dict_list[-1].copy()
         except IndexError:

--- a/cacahuate/jsontypes.py
+++ b/cacahuate/jsontypes.py
@@ -1,3 +1,7 @@
+''' Helper structures that take data from a json representation and create an
+object with specific behaviour '''
+
+
 class SortedMap:
     ''' Defines representation and serialization of a sorted map. It can be
     indexed by key or turned into a list '''
@@ -38,7 +42,8 @@ class SortedMap:
 
 
 class Map:
-    ''' a utility class for managing maps similar to SortedMap '''
+    ''' a utility class for managing maps similar to SortedMap, some logic
+    borrowed from django's QueryDict '''
 
     def __init__(self, arg, *, key=None):
         self.items = {}
@@ -61,3 +66,176 @@ class Map:
 
     def __getitem__(self, item):
         return self.items[item]
+
+
+class MultiValueMap(dict):
+    """
+    A subclass of dictionary customized to handle multiple values for the
+    same key.
+
+    >>> d = MultiValueDict({'name': ['Adrian', 'Simon'], 'position': ['Developer']})
+    >>> d['name']
+    'Simon'
+    >>> d.getlist('name')
+    ['Adrian', 'Simon']
+    >>> d.getlist('doesnotexist')
+    []
+    >>> d.getlist('doesnotexist', ['Adrian', 'Simon'])
+    ['Adrian', 'Simon']
+    >>> d.get('lastname', 'nonexistent')
+    'nonexistent'
+    >>> d.setlist('lastname', ['Holovaty', 'Willison'])
+
+    This class exists to solve the irritating problem raised by cgi.parse_qs,
+    which returns a list for every key, even though most Web forms submit
+    single name-value pairs.
+    """
+    def __init__(self, key_to_list_mapping=()):
+        super().__init__(key_to_list_mapping)
+
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, super().__repr__())
+
+    def __getitem__(self, key):
+        """
+        Return the last data value for this key, or [] if it's an empty list;
+        raise KeyError if not found.
+        """
+        try:
+            list_ = super().__getitem__(key)
+        except KeyError:
+            raise MultiValueDictKeyError(key)
+        try:
+            return list_[-1]
+        except IndexError:
+            return []
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, [value])
+
+    def __copy__(self):
+        return self.__class__([
+            (k, v[:])
+            for k, v in self.lists()
+        ])
+
+    def __deepcopy__(self, memo):
+        result = self.__class__()
+        memo[id(self)] = result
+        for key, value in dict.items(self):
+            dict.__setitem__(result, copy.deepcopy(key, memo),
+                             copy.deepcopy(value, memo))
+        return result
+
+    def __getstate__(self):
+        return {**self.__dict__, '_data': {k: self._getlist(k) for k in self}}
+
+    def __setstate__(self, obj_dict):
+        data = obj_dict.pop('_data', {})
+        for k, v in data.items():
+            self.setlist(k, v)
+        self.__dict__.update(obj_dict)
+
+    def get(self, key, default=None):
+        """
+        Return the last data value for the passed key. If key doesn't exist
+        or value is an empty list, return `default`.
+        """
+        try:
+            val = self[key]
+        except KeyError:
+            return default
+        if val == []:
+            return default
+        return val
+
+    def _getlist(self, key, default=None, force_list=False):
+        """
+        Return a list of values for the key.
+
+        Used internally to manipulate values list. If force_list is True,
+        return a new copy of values.
+        """
+        try:
+            values = super().__getitem__(key)
+        except KeyError:
+            if default is None:
+                return []
+            return default
+        else:
+            if force_list:
+                values = list(values) if values is not None else None
+            return values
+
+    def getlist(self, key, default=None):
+        """
+        Return the list of values for the key. If key doesn't exist, return a
+        default value.
+        """
+        return self._getlist(key, default, force_list=True)
+
+    def setlist(self, key, list_):
+        super().__setitem__(key, list_)
+
+    def setdefault(self, key, default=None):
+        if key not in self:
+            self[key] = default
+            # Do not return default here because __setitem__() may store
+            # another value -- QueryDict.__setitem__() does. Look it up.
+        return self[key]
+
+    def setlistdefault(self, key, default_list=None):
+        if key not in self:
+            if default_list is None:
+                default_list = []
+            self.setlist(key, default_list)
+            # Do not return default_list here because setlist() may store
+            # another value -- QueryDict.setlist() does. Look it up.
+        return self._getlist(key)
+
+    def appendlist(self, key, value):
+        """Append an item to the internal list associated with key."""
+        self.setlistdefault(key).append(value)
+
+    def items(self):
+        """
+        Yield (key, value) pairs, where value is the last item in the list
+        associated with the key.
+        """
+        for key in self:
+            yield key, self[key]
+
+    def lists(self):
+        """Yield (key, list) pairs."""
+        return iter(super().items())
+
+    def values(self):
+        """Yield the last value on every key list."""
+        for key in self:
+            yield self[key]
+
+    def copy(self):
+        """Return a shallow copy of this object."""
+        return copy.copy(self)
+
+    def update(self, *args, **kwargs):
+        """Extend rather than replace existing key lists."""
+        if len(args) > 1:
+            raise TypeError("update expected at most 1 argument, got %d" % len(args))
+        if args:
+            other_dict = args[0]
+            if isinstance(other_dict, MultiValueDict):
+                for key, value_list in other_dict.lists():
+                    self.setlistdefault(key).extend(value_list)
+            else:
+                try:
+                    for key, value in other_dict.items():
+                        self.setlistdefault(key).append(value)
+                except TypeError:
+                    raise ValueError("MultiValueDict.update() takes either a MultiValueDict or dictionary")
+        for key, value in kwargs.items():
+            self.setlistdefault(key).append(value)
+
+    def dict(self):
+        """Return current object as a dict with singular values."""
+        return {key: self[key] for key in self}

--- a/cacahuate/utils.py
+++ b/cacahuate/utils.py
@@ -94,9 +94,10 @@ def compact_values(collected_forms):
 
 
 def get_values(execution_data):
-    ''' the proper and only way that should be used to get the values out of
+    ''' the proper and only way to get the ``'values'`` key out of
     an execution document from mongo. It takes care of the transformations
-    needed for it to work in jinja templates and other contexts '''
+    needed for it to work in jinja templates and other contexts where the
+    multiplicity of answers (multiforms) is relevant. '''
     try:
         return {
             k: MultiFormDict(v) for k, v in execution_data['values'].items()

--- a/cacahuate/utils.py
+++ b/cacahuate/utils.py
@@ -7,6 +7,7 @@ from jinja2 import Template, TemplateError
 
 from cacahuate.errors import MisconfiguredProvider
 from cacahuate.models import User
+from cacahuate.jsontypes import MultiFormDict
 
 
 def user_import(module_key, class_sufix, import_maper, default_path, enabled):
@@ -90,3 +91,10 @@ def compact_values(collected_forms):
         context[form['ref']] = form_dict
 
     return context
+
+
+def get_values(execution_data):
+    ''' the proper and only way that should be used to get the values out of
+    an execution document from mongo. It takes care of the transformations
+    needed for it to work in jinja templates and other contexts '''
+    return {k: MultiFormDict(v) for k, v in execution_data['values'].items()}

--- a/cacahuate/utils.py
+++ b/cacahuate/utils.py
@@ -97,4 +97,9 @@ def get_values(execution_data):
     ''' the proper and only way that should be used to get the values out of
     an execution document from mongo. It takes care of the transformations
     needed for it to work in jinja templates and other contexts '''
-    return {k: MultiFormDict(v) for k, v in execution_data['values'].items()}
+    try:
+        return {
+            k: MultiFormDict(v) for k, v in execution_data['values'].items()
+        }
+    except KeyError:
+        return dict()

--- a/cacahuate/xml.py
+++ b/cacahuate/xml.py
@@ -166,13 +166,13 @@ class Xml:
             'finished_at': None,
             'state': self.get_state(),
             'values': {
-                '_execution': {
+                '_execution': [{
                     'id': execution.id,
                     'name': execution.name,
                     'process_name': execution.process_name,
                     'description': execution.description,
                     'started_at': datetime.now(timezone.utc).isoformat(),
-                },
+                }],
             },
             'actors': {},
         })

--- a/docs/source/develop/index.rst
+++ b/docs/source/develop/index.rst
@@ -9,3 +9,4 @@ distintos componentes de cacahuate.
 
    xml
    docs
+   utils

--- a/docs/source/develop/utils.rst
+++ b/docs/source/develop/utils.rst
@@ -1,0 +1,9 @@
+Utilidades internas
+===================
+
+Aquí se detallan algunas funciones que pueden o deben ser usadas durante el desarrollo de nuevas funcionalidades.
+
+.. autofunction:: cacahuate.utils.get_values
+
+.. autoclass:: cacahuate.jsontypes.MultiFormDict
+   :members:

--- a/docs/source/xml/index.rst
+++ b/docs/source/xml/index.rst
@@ -141,6 +141,34 @@ De manera que para usar uno de estos valores en la interpolación lo puedes enco
 
    <name>Name {{ formulario1.input1 }}</name>
 
+Formularios múltiples durante la interpolación
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Debido a que cacahuate soporta formularios múltiples estos también pueden ser usados durante la interpolación. Por defecto si ``formulario1`` tiene múltiples respuestas al hacer:
+
+.. code-block:: xml
+
+   <name>Name {{ formulario1.input1 }}</name>
+
+se utilizará la última respuesta del formulario, sin embargo es posible iterar todas las respuestas usando la función ``.all()`` del objeto :py:class:`cacahuate.jsontypes.MultiFormDict` como sigue:
+
+.. code-block:: jinja
+
+   {% for ans in formulario1.all() %}
+      {{ ans.input1 }}
+   {% endfor %}
+
+También es posible iterar los distintos valores de una llave en específico usando ``.getlist(key)`` como se detalla a continuación:
+
+.. code-block:: jinja
+
+   {% for ans in formulario1.getlist('input1') %}
+      {{ ans }}
+   {% endfor %}
+
+Este último ejemplo y el que le precede producen el mismo resultado. Para mayor información consultar la documentación de la clase.
+
+
 Valores siempre presentes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -394,10 +394,10 @@ def test_start_process(client, mocker, config, mongo):
     del reg['started_at']
     del reg['_id']
 
-    assert len(reg['values']['_execution']['id']) > 0
-    assert len(reg['values']['_execution']['started_at']) > 0
-    del reg['values']['_execution']['id']
-    del reg['values']['_execution']['started_at']
+    assert len(reg['values']['_execution'][0]['id']) > 0
+    assert len(reg['values']['_execution'][0]['started_at']) > 0
+    del reg['values']['_execution'][0]['id']
+    del reg['values']['_execution'][0]['started_at']
 
     assert reg == {
         '_type': 'execution',
@@ -463,11 +463,11 @@ def test_start_process(client, mocker, config, mongo):
             ],
         },
         'values': {
-            '_execution': {
+            '_execution': [{
                 'description': 'A simple process that does nothing',
                 'name': 'Simplest process ever started with: yes',
                 'process_name': 'simple.2018-02-19.xml',
-            },
+            }],
         },
         'actors': {},
     }

--- a/test/handler_test.py
+++ b/test/handler_test.py
@@ -7,7 +7,7 @@ from cacahuate.models import Execution, Pointer, User
 from cacahuate.node import Action, Form
 from cacahuate.xml import Xml
 
-from .utils import make_pointer, make_user, assert_near_date
+from .utils import make_pointer, make_user, assert_near_date, random_string
 
 
 def test_recover_step(config):
@@ -319,9 +319,9 @@ def test_teardown(config, mongo):
     }
 
     assert reg['values'] == {
-        'mid_form': {
+        'mid_form': [{
             'data': 'yes',
-        },
+        }],
     }
 
     assert reg['actors'] == {
@@ -481,3 +481,45 @@ def test_resistance_dead_pointer(config):
         'command': 'step',
         'pointer_id': 'nones',
     }))
+
+
+def test_compact_values(config):
+    handler = Handler(config)
+    names = [random_string() for _ in '123']
+
+    values = handler.compact_values([
+        Form.state_json('form1', [
+            {
+                'name': 'name',
+                'type': 'text',
+                'value': names[0],
+            },
+        ]),
+        Form.state_json('form1', [
+            {
+                'name': 'name',
+                'type': 'text',
+                'value': names[1],
+            },
+        ]),
+        Form.state_json('form2', [
+            {
+                'name': 'name',
+                'type': 'text',
+                'value': names[2],
+            },
+        ]),
+    ])
+
+    assert values == {
+        'values.form1': [
+            {
+                'name': name,
+            } for name in names[:2]
+        ],
+        'values.form2': [
+            {
+                'name': names[2],
+            },
+        ],
+    }

--- a/test/jsontypes_test.py
+++ b/test/jsontypes_test.py
@@ -1,4 +1,4 @@
-from cacahuate.jsontypes import SortedMap, Map
+from cacahuate.jsontypes import SortedMap, Map, MultiValueMap
 
 
 def test_sorted_map():
@@ -124,3 +124,19 @@ def test_map():
         'id': '2',
         'name': 'le',
     }
+
+
+def test_multivalued_map():
+    mv = MultiValueMap({
+        'a': [1, 2, 3],
+        'b': [4],
+    })
+
+    # by default last value is used
+    assert mv['a'] == 3
+    assert mv['b'] == 4
+
+    # values can be iterated
+    values = [1, 2, 3]
+    for i, v  in enumerate(mv.getlist('a')):
+        assert v == values[i]

--- a/test/jsontypes_test.py
+++ b/test/jsontypes_test.py
@@ -1,4 +1,6 @@
-from cacahuate.jsontypes import SortedMap, Map, MultiValueMap
+import pytest
+
+from cacahuate.jsontypes import SortedMap, Map, MultiFormDict
 
 
 def test_sorted_map():
@@ -127,16 +129,40 @@ def test_map():
 
 
 def test_multivalued_map():
-    mv = MultiValueMap({
-        'a': [1, 2, 3],
-        'b': [4],
-    })
+    ulist = [
+        {
+            'a': 'a',
+            'b': 1,
+        },
+        {
+            'b': 2,
+        },
+        {
+            'a': 'b',
+            'b': 3,
+        },
+    ]
+    mv = MultiFormDict(ulist)
 
     # by default last value is used
-    assert mv['a'] == 3
-    assert mv['b'] == 4
+    assert mv['b'] == 3
 
-    # values can be iterated
-    values = [1, 2, 3]
-    for i, v  in enumerate(mv.getlist('a')):
-        assert v == values[i]
+    with pytest.raises(KeyError):
+        mv['da']
+
+    assert mv.get('b') == 3
+    assert mv.get('c', 40) == 40
+
+    assert mv.getlist('b') == [1, 2, 3]
+    assert mv.getlist('a', 'c') == ['a', 'c', 'b']
+
+    assert mv.list() == ulist
+
+    assert list(mv.items()) == [('a', 'b'), ('b', 3)]
+    assert list(mv.values()) == ['b', 3]
+    assert list(mv.keys()) == ['a', 'b']
+
+    assert mv.dict() == {
+        'a': 'b',
+        'b': 3,
+    }

--- a/test/jsontypes_test.py
+++ b/test/jsontypes_test.py
@@ -156,8 +156,7 @@ def test_multivalued_map():
     assert mv.getlist('b') == [1, 2, 3]
     assert mv.getlist('a', 'c') == ['a', 'c', 'b']
 
-    assert mv.list() == ulist
-
+    assert list(mv.all()) == ulist
     assert list(mv.items()) == [('a', 'b'), ('b', 3)]
     assert list(mv.values()) == ['b', 3]
     assert list(mv.keys()) == ['a', 'b']

--- a/test/node_test.py
+++ b/test/node_test.py
@@ -13,9 +13,9 @@ def test_resolve_params(config):
 
     state = {
         'values': {
-            'exit_form': {
+            'exit_form': [{
                 'reason': 'nones',
-            },
+            }],
         },
         'actors': {
             'requester': 'juan',

--- a/test/nodes/if_test.py
+++ b/test/nodes/if_test.py
@@ -809,13 +809,13 @@ def test_invalidated_conditional(config, mongo):
         },
         'status': 'finished',
         'values': {
-            'form1': {'value': -3},
-            'if_node': {'condition': False},
-            'validation_node': {
+            'form1': [{'value': -3}],
+            'if_node': [{'condition': False}],
+            'validation_node': [{
                 'comment': 'I do not like it',
                 'inputs': [{'ref': 'start_node.juan.0:form1.value'}],
                 'response': 'reject',
-            },
+            }],
         },
         'actors': {
             'start_node': 'juan',

--- a/test/nodes/request_test.py
+++ b/test/nodes/request_test.py
@@ -425,17 +425,22 @@ def test_store_data_from_response(config, mocker, mongo):
         'description': 'Request request_node',
     }
     assert state['values'] == {
-        'capture1': {
+        'capture1': [{
             'name': expected_name,
-        },
-        'capture2': {
-            'age': expected_age_2,
-        },
-        'request': {
+        }],
+        'capture2': [
+            {
+                'age': expected_age_1,
+            },
+            {
+                'age': expected_age_2,
+            },
+        ],
+        'request': [{
             'data': value,
-        },
-        'request_node': {
+        }],
+        'request_node': [{
             'raw_response': request_response_s,
             'status_code': 200,
-        },
+        }],
     }

--- a/test/nodes/validation_test.py
+++ b/test/nodes/validation_test.py
@@ -303,11 +303,11 @@ def test_reject(config, mongo):
             'item_order': ['start_node', 'approval_node', 'final_node'],
         },
         'values': {
-            'approval_node': {
+            'approval_node': [{
                 'comment': 'I do not like it',
                 'response': 'reject',
                 'inputs': [{'ref': 'start_node.juan.0:work.task'}],
-            },
+            }],
         },
         'actors': {
             'approval_node': 'juan',
@@ -684,15 +684,15 @@ def test_reject_with_dependencies(config, mongo):
         },
         'status': 'finished',
         'values': {
-            'node4': {
+            'node4': [{
                 'comment': 'I like it',
                 'inputs': None,
                 'response': 'accept',
-            },
-            'form1': {'task': '2'},
-            'form2': {'task': '2'},
-            'form3': {'task': '1'},
-            'form5': {'task': '1'},
+            }],
+            'form1': [{'task': '2'}],
+            'form2': [{'task': '2'}],
+            'form3': [{'task': '1'}],
+            'form5': [{'task': '1'}],
         },
         'actors': {
             'node1': 'juan',

--- a/test/storage_test.py
+++ b/test/storage_test.py
@@ -1,9 +1,8 @@
 from unittest.mock import MagicMock
-import simplejson as json
 import requests
 
 from cacahuate.handler import Handler
-from cacahuate.models import Execution, Pointer
+from cacahuate.models import Pointer
 from cacahuate.node import Form
 from cacahuate.xml import Xml
 from cacahuate.utils import get_values

--- a/test/storage_test.py
+++ b/test/storage_test.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+import simplejson as json
+import requests
+
+from cacahuate.handler import Handler
+from cacahuate.models import Execution, Pointer
+from cacahuate.node import Form
+from cacahuate.xml import Xml
+
+from .utils import make_pointer, make_user, random_string
+
+
+def test_send_request_multiple(config, mongo, mocker):
+    ''' Tests that values are stored in such a way that they can be iterated
+    in a jinja template. Specifically in this test they'll be used as part of
+    a request node, thus also testing that all of the values can be used '''
+    # test setup
+    class ResponseMock:
+        status_code = 200
+        text = 'request response'
+
+    mock = MagicMock(return_value=ResponseMock())
+
+    mocker.patch(
+        'requests.request',
+        new=mock
+    )
+
+    handler = Handler(config)
+    user = make_user('juan', 'Juan')
+    ptr = make_pointer('request-multiple.2019-11-14.xml', 'start_node')
+    execution = ptr.proxy.execution.get()
+    channel = MagicMock()
+    names = [random_string() for _ in '123']
+
+    mongo[config["EXECUTION_COLLECTION"]].insert_one({
+        '_type': 'execution',
+        'id': execution.id,
+        'state': Xml.load(config, execution.process_name).get_state(),
+    })
+
+    handler.call({
+        'command': 'step',
+        'pointer_id': ptr.id,
+        'user_identifier': user.identifier,
+        'input': [
+            Form.state_json('form1', [
+                {
+                    'name': 'name',
+                    'type': 'text',
+                    'value': names[0],
+                },
+            ]),
+            Form.state_json('form1', [
+                {
+                    'name': 'name',
+                    'type': 'text',
+                    'value': names[1],
+                },
+            ]),
+            Form.state_json('form1', [
+                {
+                    'name': 'name',
+                    'type': 'text',
+                    'value': names[2],
+                },
+            ]),
+        ],
+    }, channel)
+
+    # pointer moved
+    assert Pointer.get(ptr.id) is None
+    ptr = Pointer.get_all()[0]
+    assert ptr.node_id == 'request_node'
+
+    # request is made with correct data
+    requests.request.assert_called_once()
+    args, kwargs = requests.request.call_args
+
+    assert args[0] == 'POST'
+    assert args[1] == 'http://localhost/'
+
+    assert kwargs['data'] == '{{"names": ["{}","{}","{}"]}}'.format(*names)
+    assert kwargs['headers'] == {
+        'content-type': 'application/json',
+    }

--- a/test/storage_test.py
+++ b/test/storage_test.py
@@ -27,7 +27,7 @@ def test_get_values():
     context = get_values(execution)
 
     assert context['form1']['input1'] == 'B'
-    assert context['form1'].list()[0]['input1'] == 'A'
+    assert list(context['form1'].all())[0]['input1'] == 'A'
 
 
 def test_send_request_multiple(config, mongo, mocker):

--- a/test/storage_test.py
+++ b/test/storage_test.py
@@ -6,8 +6,29 @@ from cacahuate.handler import Handler
 from cacahuate.models import Execution, Pointer
 from cacahuate.node import Form
 from cacahuate.xml import Xml
+from cacahuate.utils import get_values
 
 from .utils import make_pointer, make_user, random_string
+
+
+def test_get_values():
+    execution = {
+        'values': {
+            'form1': [
+                {
+                    'input1': 'A',
+                },
+                {
+                    'input1': 'B',
+                },
+            ],
+        },
+    }
+
+    context = get_values(execution)
+
+    assert context['form1']['input1'] == 'B'
+    assert context['form1'].list()[0]['input1'] == 'A'
 
 
 def test_send_request_multiple(config, mongo, mocker):

--- a/xml/request-multiple.2019-11-14.xml
+++ b/xml/request-multiple.2019-11-14.xml
@@ -27,7 +27,7 @@
       <headers>
         <header name="content-type">application/json</header>
       </headers>
-      <body>{"names": [{% for resp in form1.list() %}"{{ resp.name }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
+      <body>{"names": [{% for resp in form1.all() %}"{{ resp.name }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
     </request>
   </process>
 </process-spec>

--- a/xml/request-multiple.2019-11-14.xml
+++ b/xml/request-multiple.2019-11-14.xml
@@ -28,7 +28,7 @@
       <headers>
         <header name="content-type">application/json</header>
       </headers>
-      <body>{"names": [{% for resp in form1 %}"{{ resp.input1 }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
+      <body>{"names": [{% for resp in form1.list() %}"{{ resp.input1 }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
     </request>
   </process>
 </process-spec>

--- a/xml/request-multiple.2019-11-14.xml
+++ b/xml/request-multiple.2019-11-14.xml
@@ -23,7 +23,6 @@
     </action>
 
     <request id="request_node" method="POST">
-      <method>POST</method>
       <url>http://localhost/</url>
       <headers>
         <header name="content-type">application/json</header>

--- a/xml/request-multiple.2019-11-14.xml
+++ b/xml/request-multiple.2019-11-14.xml
@@ -28,7 +28,7 @@
       <headers>
         <header name="content-type">application/json</header>
       </headers>
-      <body>{"names": [{% for resp in form1.list() %}"{{ resp.input1 }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
+      <body>{"names": [{% for resp in form1.list() %}"{{ resp.name }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
     </request>
   </process>
 </process-spec>

--- a/xml/request-multiple.2019-11-14.xml
+++ b/xml/request-multiple.2019-11-14.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://tracsa.github.io/vi-xml/proceso_transform.xsl" ?>
+<process-spec>
+  <process-info>
+    <author>Abraham</author>
+    <date>2019-11-14</date>
+    <name>Request multiple test</name>
+    <public>false</public>
+    <description>This test proves that is possible to iterate and send all the values captured in a multiple form.</description>
+  </process-info>
+  <process>
+    <action id="start_node" >
+      <node-info>
+        <name>Capture data</name>
+        <description>Capture a multiple form</description>
+      </node-info>
+      <auth-filter backend="anyone"></auth-filter>
+      <form-array>
+        <form id="form1" multiple="multiple">
+          <input type="text" name="name" label="The name"></input>
+        </form>
+      </form-array>
+    </action>
+
+    <request id="request_node" method="POST">
+      <method>POST</method>
+      <url>http://localhost/</url>
+      <headers>
+        <header name="content-type">application/json</header>
+      </headers>
+      <body>{"names": [{% for resp in form1 %}"{{ resp.input1 }}"{% if not loop.last %},{% endif %}{% endfor %}]}</body>
+    </request>
+  </process>
+</process-spec>


### PR DESCRIPTION
Lo que sucede aquí altera de forma fundamental cómo se utiliza y obtiene el contexto guardado en la llave 'values' del documento en mongo de una ejecución. Se añade una función `get_values()` que ahora es la única y verdadera manera de extraer dicha llave, ya que realiza transformaciones en ella necesarias para su adecuado uso en templates. Los cambios tocan muchas partes pero solo en la API de summary no hay tests para probar que funciona, aunque presumiblemente lo haría.