### PR TITLE
allowDisk use in inbox aggregate

### DIFF
--- a/cacahuate/http/views/api.py
+++ b/cacahuate/http/views/api.py
@@ -892,7 +892,7 @@ def data_mix():
     return jsonify({
         'data': list(map(
             data_mix_json_prepare,
-            exe_collection.aggregate(exe_pipeline),
+            exe_collection.aggregate(exe_pipeline, allowDiskUse=True),
         ))
     })
 


### PR DESCRIPTION
Avoid `sort exceeded memory limit` allowing disk usage.